### PR TITLE
Fix --version command

### DIFF
--- a/bin/apostrophe
+++ b/bin/apostrophe
@@ -4,8 +4,9 @@ require('shelljs/global');
 require('colors');
 var program = require('commander');
 var util = require('../lib/util');
+var pkginfo = require('pkginfo')(module, 'version');
 
-program.version('2.0.0');
+program.version(module.exports.version);
 
 util.checkDependencies();
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "colors": "~1.0.x",
     "commander": "~2.5.x",
     "lodash": "^4.17.4",
+    "pkginfo": "^0.4.1",
     "prompt": "^0.2.14",
     "shelljs": "~0.3.x"
   },


### PR DESCRIPTION
Removes hard coded version number and adds [node-pkginfo](https://www.npmjs.com/package/pkginfo) to fetch version from package.json file.

`pkginfo` seems rather old, but has over 400k downloads per week and no known vulnerabilities.

#20