### PR TITLE
Add version of apostrophe to apos --version output

### DIFF
--- a/bin/apostrophe
+++ b/bin/apostrophe
@@ -16,10 +16,16 @@ function getVersion() {
   var output = 'apostrophe-cli: ' + module.exports.version;
   var aposPath = cwd + '/node_modules/apostrophe/';
 
-  // Append version of apostrophe if installed.
+  // Append message for apostrophe.
   if (fs.existsSync(aposPath)) {
     var package = require(aposPath + 'package.json');
-    output += ', apostrophe: ' + package.version;
+
+    output += 'apostrophe v' + package.version + ' is installed in the current directory.';
+  } else {
+    var execSync = require('child_process').execSync;
+    var aposVersion = execSync('npm view apostrophe version').toString();
+
+    output += 'apostrophe v' + aposVersion.trim() + ' (latest) will be installed with a new project.';
   }
 
   return output;

--- a/bin/apostrophe
+++ b/bin/apostrophe
@@ -13,7 +13,7 @@ function getVersion() {
   var pkginfo = require('pkginfo')(module, 'version');
   var cwd = process.cwd();
 
-  var output = 'apostrophe-cli: ' + module.exports.version;
+  var output = 'apostrophe-cli: v' + module.exports.version + '\n';
   var aposPath = cwd + '/node_modules/apostrophe/';
 
   // Append message for apostrophe.
@@ -22,20 +22,19 @@ function getVersion() {
 
     output += 'apostrophe v' + package.version + ' is installed in this project.';
   } else {
-    var request = require('request');
+    var request = require('sync-request');
+    var response = request('GET', 'https://raw.githubusercontent.com/apostrophecms/apostrophe-boilerplate/master/package.json');
 
-    request.get('https://raw.githubusercontent.com/apostrophecms/apostrophe-boilerplate/master/package.json', function (error, response, body) {
-      if (!error && response.statusCode == 200) {
-        var packageJSON = JSON.parse(body);
+    if (response.statusCode == 200) {
+      var packageJSON = JSON.parse(response.body);
 
-        output += 'apostrophe v' + packageJSON.version + ' will be installed with a new project, according to the dependencies of apostrophe-boilerplate.';
-      } else {
-        var execSync = require('child_process').execSync;
-        var aposVersion = execSync('npm view apostrophe version').toString();
+      output += 'apostrophe ' + packageJSON.dependencies.apostrophe + ' will be installed with a new project, according to the dependencies of apostrophe-boilerplate.';
+    } else {
+      var execSync = require('child_process').execSync;
+      var aposVersion = execSync('npm view apostrophe version').toString();
 
-        output += 'apostrophe v' + aposVersion.trim() + ' (latest) will be installed with a new project, unless the boilerplate project\'s dependencies specify otherwise.';
-      }
-    });
+      output += 'apostrophe v' + aposVersion.trim() + ' (latest) will be installed with a new project, unless the boilerplate project\'s dependencies specify otherwise.';
+    }
   }
 
   return output;

--- a/bin/apostrophe
+++ b/bin/apostrophe
@@ -22,10 +22,20 @@ function getVersion() {
 
     output += 'apostrophe v' + package.version + ' is installed in this project.';
   } else {
-    var execSync = require('child_process').execSync;
-    var aposVersion = execSync('npm view apostrophe version').toString();
+    var request = require('request');
 
-    output += 'apostrophe v' + aposVersion.trim() + ' (latest) will be installed with a new project, unless the boilerplate project\'s dependencies specify otherwise.';
+    request.get('https://raw.githubusercontent.com/apostrophecms/apostrophe-boilerplate/master/package.json', function (error, response, body) {
+      if (!error && response.statusCode == 200) {
+        var packageJSON = JSON.parse(body);
+
+        output += 'apostrophe v' + packageJSON.version + ' will be installed with a new project, according to the dependencies of apostrophe-boilerplate.';
+      } else {
+        var execSync = require('child_process').execSync;
+        var aposVersion = execSync('npm view apostrophe version').toString();
+
+        output += 'apostrophe v' + aposVersion.trim() + ' (latest) will be installed with a new project, unless the boilerplate project\'s dependencies specify otherwise.';
+      }
+    });
   }
 
   return output;

--- a/bin/apostrophe
+++ b/bin/apostrophe
@@ -20,7 +20,7 @@ function getVersion() {
   if (fs.existsSync(aposPath)) {
     var package = require(aposPath + 'package.json');
 
-    output += 'apostrophe v' + package.version + ' is installed in the current directory.';
+    output += 'apostrophe v' + package.version + ' is installed in this project.';
   } else {
     var execSync = require('child_process').execSync;
     var aposVersion = execSync('npm view apostrophe version').toString();

--- a/bin/apostrophe
+++ b/bin/apostrophe
@@ -25,7 +25,7 @@ function getVersion() {
     var execSync = require('child_process').execSync;
     var aposVersion = execSync('npm view apostrophe version').toString();
 
-    output += 'apostrophe v' + aposVersion.trim() + ' (latest) will be installed with a new project.';
+    output += 'apostrophe v' + aposVersion.trim() + ' (latest) will be installed with a new project, unless the boilerplate project\'s dependencies specify otherwise.';
   }
 
   return output;

--- a/bin/apostrophe
+++ b/bin/apostrophe
@@ -4,9 +4,26 @@ require('shelljs/global');
 require('colors');
 var program = require('commander');
 var util = require('../lib/util');
-var pkginfo = require('pkginfo')(module, 'version');
+var fs = require('fs');
 
-program.version(module.exports.version);
+program.version(getVersion());
+
+// Get version of apostrophe-cli and apostrophe.
+function getVersion() {
+  var pkginfo = require('pkginfo')(module, 'version');
+  var cwd = process.cwd();
+
+  var output = 'apostrophe-cli: ' + module.exports.version;
+  var aposPath = cwd + '/node_modules/apostrophe/';
+
+  // Append version of apostrophe if installed.
+  if (fs.existsSync(aposPath)) {
+    var package = require(aposPath + 'package.json');
+    output += ', apostrophe: ' + package.version;
+  }
+
+  return output;
+}
 
 util.checkDependencies();
 

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "lodash": "^4.17.4",
     "pkginfo": "^0.4.1",
     "prompt": "^0.2.14",
-    "request": "^2.87.0",
-    "shelljs": "~0.3.x"
+    "shelljs": "~0.3.x",
+    "sync-request": "^6.0.0"
   },
   "preferGlobal": true,
   "bin": {


### PR DESCRIPTION
If `apostrophe` is installed in the current working directory, the version will be appended to `apostrophe-cli`'s version.

Since I am fairly new to Node.js and ApostropheCMS, I am not sure if this is the best way of doing it.

Addition to pull request #21.
Finally closes issue #20.