### PR TITLE
Document apos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.3.4 - May 18, 2020
+
+* Documents and prioritizes the existing `apos` command alias as the CLI command.
+
 ## 2.3.3 - May 6, 2020
 
 * Cleans up CLI output spacing. Also adds ESLint testing and documents the `--boilerplate` option.

--- a/README.md
+++ b/README.md
@@ -36,12 +36,26 @@ To bootstrap the necessary files and basic configuration for a new Apostrophe wi
 apos create-widget fancy-button
 ```
 
+**Note:** You will then need to register this widget module in `app.js` so it is available in your project code. The same is true for the commands below when you create a piece module or generic module.
+
+```javascript
+// app.js
+module.exports = {
+  // ...
+  'fancy-button-widgets': {},
+  // ...
+}
+```
+
+
 ## Create a piece
 To bootstrap the necessary files and basic configuration for a new Apostrophe piece type, run the following command from within your Apostrophe project's root directory:
 ```bash
 # be sure to use the SINGULAR version of the name of your content type
 apos create-piece vegetable
 ```
+
+Then remember to register `'vegetables': {}` in `apps.js` above.
 
 If you run the `create-piece` command with the `--pages` flag, the command will also set up a corresponding pieces-pages module with your new piece type. Similarly, you can run the `create-piece` command with the `--widgets` flag, which will also set up a corresponding pieces-widgets module along with your new piece type. These flags can be used together or separately.
 
@@ -54,6 +68,8 @@ To bootstrap the necessary files and basic configuration for a brand-new Apostro
 ```bash
 apos create-module <module name>
 ```
+
+Remember to register the module in `apps.js` with the other module types.
 
 ## Run other Apostrophe-flavored command-line tasks
 

--- a/README.md
+++ b/README.md
@@ -9,23 +9,23 @@ npm install -g apostrophe-cli
 
 To view the available commands in a given context, execute the newly-installed command with no arguments:
 ```bash
-apostrophe
+apos
 ```
 
-**Note:** All Apostrophe CLI commands can also be run with the abbreviated `apos` command, in addition to `apostrophe`.
+**Note:** All Apostrophe CLI commands can also be run with `apostrophe`, the legacy command, in addition to `apos`.
 
 ## Create a project
 
 To create a new project with the tool:
 ```bash
-apostrophe create-project <shortname-without-spaces>
+apos create-project <shortname-without-spaces>
 ```
 
 This will create a local copy of our standard [Apostrophe Boilerplate](https://github.com/apostrophecms/apostrophe-boilerplate).
 
 ### options
 
-Run `create-project` with a `--boilerplate` flag to start from a Github repository other than the standard `apostrophe-boilerplate` repo. For example, `apostrophe create-project <shortname-without-spaces> --boilerplate=https://github.com/apostrophecms/apostrophe-open-museum.git` would create a project using the [Open Museum](https://github.com/apostrophecms/apostrophe-open-museum) demo.
+Run `create-project` with a `--boilerplate` flag to start from a Github repository other than the standard `apostrophe-boilerplate` repo. For example, `apos create-project <shortname-without-spaces> --boilerplate=https://github.com/apostrophecms/apostrophe-open-museum.git` would create a project using the [Open Museum](https://github.com/apostrophecms/apostrophe-open-museum) demo.
 
 If you run the `create-project` command with the `--setup` flag, the command will also `npm install` the dependencies for the project and run `apostrophe-users:add` to create an admin user for the CMS, resulting in a fully bootstrapped project. This command will prompt you for a password for the admin user being created.
 
@@ -33,38 +33,40 @@ If you run the `create-project` command with the `--setup` flag, the command wil
 To bootstrap the necessary files and basic configuration for a new Apostrophe widget, run the following command from within your Apostrophe project's root directory:
 ```bash
 # "-widgets" will automatically be appended to the end of your module name
-apostrophe create-widget fancy-button
+apos create-widget fancy-button
 ```
 
 ## Create a piece
 To bootstrap the necessary files and basic configuration for a new Apostrophe piece type, run the following command from within your Apostrophe project's root directory:
 ```bash
 # be sure to use the SINGULAR version of the name of your content type
-apostrophe create-piece vegetable
+apos create-piece vegetable
 ```
 
 If you run the `create-piece` command with the `--pages` flag, the command will also set up a corresponding pieces-pages module with your new piece type. Similarly, you can run the `create-piece` command with the `--widgets` flag, which will also set up a corresponding pieces-widgets module along with your new piece type. These flags can be used together or separately.
 
 ```bash
-apostrophe create-piece vegetable --pages --widgets
+apos create-piece vegetable --pages --widgets
 ```
 
 ## Create an empty Apostrophe module
 To bootstrap the necessary files and basic configuration for a brand-new Apostrophe module that doesn't extend one of the usual suspects like pieces or widgets:
 ```bash
-apostrophe create-module <module name>
+apos create-module <module name>
 ```
 
 ## Run other Apostrophe-flavored command-line tasks
 
 To run an Apostrophe command-line task with the Apostrophe CLI, which are conventionally run like this: `node app.js <namespace>:<task name>`, you may instead execute the following from any location within a project's directory:
 ```bash
-apostrophe <namespace>:<task name>
+apos <namespace>:<task name>
 ```
+
+
 
 The Apostrophe CLI assumes the `apostrophe` namespace when executing tasks. This means that if a task is in the `apostrophe` namespace (such as the `apostrophe:generation` task), you can simply execute:
 ```bash
-apostrophe <task name>
+apos <task name>
 ```
 
 For more information on command-line tasks in Apostrophe, visit the [Command line tasks](https://docs.apostrophecms.org/reference/modules/apostrophe-tasks.html) documentation for Apostrophe.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# apostrophe-cli
+# Apostrophe CLI
 
-The apostrophe-cli is a cross-platform starting point for creating and configuring [ApostropheCMS](https://github.com/apostrophecms/apostrophe) projects, providing a simple boilerplate generator and wrapping other useful functions into an easy to use command line tool.
+The Apostrophe CLI is a cross-platform starting point for creating and configuring [ApostropheCMS](https://github.com/apostrophecms/apostrophe) projects, providing a simple boilerplate generator and wrapping other useful functions into an easy to use command line tool.
 
-First, install apostrophe-cli as a global NPM module:
+First, install `apostrophe-cli` as a global NPM module:
 ```bash
 npm install -g apostrophe-cli
 ```
@@ -11,6 +11,8 @@ To view the available commands in a given context, execute the newly-installed c
 ```bash
 apostrophe
 ```
+
+**Note:** All Apostrophe CLI commands can also be run with the abbreviated `apos` command, in addition to `apostrophe`.
 
 ## Create a project
 
@@ -55,18 +57,18 @@ apostrophe create-module <module name>
 
 ## Run other Apostrophe-flavored command-line tasks
 
-To run an Apostrophe command-line task with the apostrophe-cli, which are conventionally run like this: `node app.js <namespace>:<task name>`, you may instead execute the following from any location within a project's directory:
+To run an Apostrophe command-line task with the Apostrophe CLI, which are conventionally run like this: `node app.js <namespace>:<task name>`, you may instead execute the following from any location within a project's directory:
 ```bash
 apostrophe <namespace>:<task name>
 ```
 
-The apostrophe-cli assumes the `apostrophe` namespace when executing tasks. This means that if a task is in the `apostrophe` namespace (such as the `apostrophe:reset` task), you can simply execute:
+The Apostrophe CLI assumes the `apostrophe` namespace when executing tasks. This means that if a task is in the `apostrophe` namespace (such as the `apostrophe:generation` task), you can simply execute:
 ```bash
 apostrophe <task name>
 ```
 
-For more information on command-line tasks in Apostrophe, visit the [Command line tasks](https://docs.apostrophecms.org/apostrophe/reference/modules/apostrophe-tasks) documentation for Apostrophe.
+For more information on command-line tasks in Apostrophe, visit the [Command line tasks](https://docs.apostrophecms.org/reference/modules/apostrophe-tasks.html) documentation for Apostrophe.
 
 ---------------
 
-For more documentation on Apostrophe, visit the [documentation site](https://docs.apostrophecms.org).
+For more documentation for ApostropheCMS, visit the [documentation site](https://docs.apostrophecms.org).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apostrophe-cli",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "description": "Commandline generator and configurator for Apostrophe CMS",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Sets in the documentation that the shorthand `apos` is a preferred alternative to `apostrophe`